### PR TITLE
fix: corrigir bug de alterar cor dos previews pelos inputs

### DIFF
--- a/src/app/components/config/components/presets/presets.ts
+++ b/src/app/components/config/components/presets/presets.ts
@@ -95,6 +95,17 @@ export class Presets implements OnInit{
           colorOfTextChange: "#B87333",
           colorOfTextRemove: "#573105ff"
         },
+        previewConfigSide: {
+          config: "#5ACF5D",
+          content: "#B87333",
+          text: "#833434",
+          icon: "#873408",
+          allButton: {
+            circleColor: "#f36a1bff",
+            activeBtn: "#573105ff",
+            inactiveBtn: "#945c1bff",
+          }
+        },
         changeColorService: this.changeColorService,
         localStorageService: this.localStorageService
       }),
@@ -121,6 +132,17 @@ export class Presets implements OnInit{
           colorOfTextChange: "#e30057ff",
           colorOfTextRemove: "#FF006F"
         },
+        previewConfigSide: {
+          config: "#FF69B4",
+          content: "#800080",
+          text: "#FF006F",
+          icon: "#E9AEF9",
+          allButton: {
+            circleColor: "#d310daff",
+            activeBtn: "#A909E8",
+            inactiveBtn: "#E3009B",
+          }
+        },
         changeColorService: this.changeColorService,
         localStorageService: this.localStorageService
       }),
@@ -146,6 +168,17 @@ export class Presets implements OnInit{
           colorOfRemove: "#C0C0C0",
           colorOfTextChange: "#C0C0C0",
           colorOfTextRemove: "#277679ff"
+        },
+        previewConfigSide: {
+          config: "#4682B4",
+          content: "#C0C0C0",
+          text: "#000000",
+          icon: "#3E2723",
+          allButton: {
+            circleColor: "#3E2723",
+            activeBtn: "#277679ff",
+            inactiveBtn: "#78a9b1ff",
+          }
         },
         changeColorService: this.changeColorService,
         localStorageService: this.localStorageService

--- a/src/app/components/config/components/settings-side/settings-side.ts
+++ b/src/app/components/config/components/settings-side/settings-side.ts
@@ -97,13 +97,15 @@ export class SettingsSide implements OnInit{
   ngOnInit(): void {
     this.ChangeColorService.$colorVal.subscribe((val: ChangeColorI) => {
       this.settings_side.forEach((settingSide: SettingsSideModel) => {
-        settingSide.colors.conteudo = val.colorContent ? val.colorContent : "#2c2c2c";
-        settingSide.colors.colorIcon = val.colorIcon ? val.colorIcon : "#000000";
-        settingSide.colors.button!.circleColor = val.colorAllButton?.circleColor ? val.colorAllButton.circleColor : "#f5deb3";
-        settingSide.colors.button!.active.buttonColor = val.colorAllButton?.active.buttonColor ? val.colorAllButton.active.buttonColor : "#C0C0C0";
-        settingSide.colors.button!.inactive.buttonColor = val.colorAllButton?.inactive.buttonColor ? val.colorAllButton.inactive.buttonColor : "#2c2c2c";
-        settingSide.colors.colorText = val.colorText ? val.colorText : "#FFFFFF";
-        settingSide.colors.colorConfig = val.colorConfig ? val.colorConfig : "darkred";
+        if(!val.previewConfigSide) return;
+
+        settingSide.colors.conteudo = val.previewConfigSide!.content;
+        settingSide.colors.colorIcon = val.previewConfigSide!.icon;
+        settingSide.colors.colorText = val.previewConfigSide!.text;
+        settingSide.colors.colorConfig = val.previewConfigSide!.config;
+        settingSide.colors.button!.circleColor = val.previewConfigSide!.allButton.circleColor;
+        settingSide.colors.button!.active.buttonColor = val.previewConfigSide!.allButton.activeBtn;
+        settingSide.colors.button!.inactive.buttonColor = val.previewConfigSide!.allButton.inactiveBtn;
       });
     })
 

--- a/src/app/components/config/config.ts
+++ b/src/app/components/config/config.ts
@@ -113,7 +113,8 @@ export class Config implements OnInit, AfterViewInit{
           textColor: presetActive.colorAllButton!.inactive.textColor
         }
       },
-      animationText: presetActive.animationText
+      animationText: presetActive.animationText,
+      previewConfigSide: presetActive.previewConfigSide
     });
   }
 
@@ -170,7 +171,8 @@ export class Config implements OnInit, AfterViewInit{
                   textColor: preset.colorAllButton!.inactive.textColor
                 }
               },
-              animationText: preset.animationText
+              animationText: preset.animationText,
+              previewConfigSide: preset.previewConfigSide
             });
 
             return;
@@ -203,7 +205,18 @@ export class Config implements OnInit, AfterViewInit{
               colorOfRemove: "#C0C0C0",
               colorOfTextChange: "#C0C0C0",
               colorOfTextRemove: "#2c2c2c"
-            }
+            },
+            previewConfigSide: {
+              config: "darkred",
+              content: "#2c2c2c",
+              text: "white",
+              icon: "black",
+              allButton: {
+                circleColor: "#f5deb3",
+                activeBtn: "#C0C0C0",
+                inactiveBtn: "#2c2c2c",
+              }
+            },
           })
         }
       }),

--- a/src/app/interfaces/change-color-i.ts
+++ b/src/app/interfaces/change-color-i.ts
@@ -19,5 +19,16 @@ export interface ChangeColorI {
     colorOfRemove: string;
     colorOfTextChange: string;
     colorOfTextRemove: string;
+  },
+  previewConfigSide?: {
+    config: string;
+    content: string;
+    text: string;
+    icon: string;
+    allButton: {
+      circleColor: string;
+      activeBtn: string;
+      inactiveBtn: string;
+    }
   }
 }

--- a/src/app/models/change_color_pre/change-color-pre.ts
+++ b/src/app/models/change_color_pre/change-color-pre.ts
@@ -16,6 +16,7 @@ export class ChangeColorPre {
   colorIcon: string;
   colorAllButton: ChangeColorI["colorAllButton"];
   animationText: ChangeColorI["animationText"];
+  previewConfigSide: ChangeColorI["previewConfigSide"];
   changeColorService: ChangeColor;
   localStorageService: LocalStorage;
 
@@ -27,6 +28,7 @@ export class ChangeColorPre {
     this.colorIcon = val.colorIcon!;
     this.colorAllButton = val.colorAllButton!;
     this.animationText = val.animationText!;
+    this.previewConfigSide = val.previewConfigSide!;
     this.changeColorService = val.changeColorService;
     this.localStorageService = val.localStorageService;
   }
@@ -40,7 +42,8 @@ export class ChangeColorPre {
       colorText: this.colorText,
       colorIcon: this.colorIcon,
       colorAllButton: this.colorAllButton,
-      animationText: this.animationText
+      animationText: this.animationText,
+      previewConfigSide: this.previewConfigSide
     });
   }
 }


### PR DESCRIPTION
### Correção de bug nas cores do preview de configuração

Corrige um problema em que os inputs individuais (destinatários: config, content, text, icon) estavam alterando indevidamente a cor do preview da **Config Side**. Agora, cada input afeta apenas seu destinatário correspondente, evitando alterações inesperadas no preview geral.
