### PR TITLE
feat: mudar a cor do preview sideConfig de acordo com os inputs 

### DIFF
--- a/src/app/components/config/components/presets/presets.ts
+++ b/src/app/components/config/components/presets/presets.ts
@@ -32,7 +32,10 @@ export class Presets implements OnInit{
       colorInput: "#8B0000",
       changeColor: (color: string) => {
         this.changeColorService.setColorVal({
-          colorConfig: color
+          colorConfig: color,
+          previewConfigSide: {
+            config: color
+          }
         })
       }
     }),
@@ -42,7 +45,10 @@ export class Presets implements OnInit{
       colorInput: "#2c2c2c",
       changeColor: (color: string) => {
         this.changeColorService.setColorVal({
-          colorContent: color
+          colorContent: color,
+          previewConfigSide: {
+            content: color
+          }
         })
       }
     }),
@@ -52,7 +58,10 @@ export class Presets implements OnInit{
       colorInput: "#FFFFFF",
       changeColor: (color: string) => {
         this.changeColorService.setColorVal({
-          colorText: color
+          colorText: color,
+          previewConfigSide: {
+            text: color
+          }
         });
       }
     }),
@@ -62,7 +71,10 @@ export class Presets implements OnInit{
       colorInput: "#000000",
       changeColor: (color: string) => {
         this.changeColorService.setColorVal({
-          colorIcon: color
+          colorIcon: color,
+          previewConfigSide: {
+            icon: color
+          }
         });
       }
     })

--- a/src/app/components/config/components/settings-side/settings-side.ts
+++ b/src/app/components/config/components/settings-side/settings-side.ts
@@ -99,13 +99,13 @@ export class SettingsSide implements OnInit{
       this.settings_side.forEach((settingSide: SettingsSideModel) => {
         if(!val.previewConfigSide) return;
 
-        settingSide.colors.conteudo = val.previewConfigSide!.content;
-        settingSide.colors.colorIcon = val.previewConfigSide!.icon;
-        settingSide.colors.colorText = val.previewConfigSide!.text;
-        settingSide.colors.colorConfig = val.previewConfigSide!.config;
-        settingSide.colors.button!.circleColor = val.previewConfigSide!.allButton.circleColor;
-        settingSide.colors.button!.active.buttonColor = val.previewConfigSide!.allButton.activeBtn;
-        settingSide.colors.button!.inactive.buttonColor = val.previewConfigSide!.allButton.inactiveBtn;
+        settingSide.colors.conteudo = val.previewConfigSide.content ?? settingSide.colors.conteudo;
+        settingSide.colors.colorIcon = val.previewConfigSide.icon ?? settingSide.colors.colorIcon;
+        settingSide.colors.colorText = val.previewConfigSide.text ?? settingSide.colors.colorText;
+        settingSide.colors.colorConfig = val.previewConfigSide.config ?? settingSide.colors.colorConfig;
+        settingSide.colors.button!.circleColor = val.previewConfigSide.allButton?.circleColor ?? settingSide.colors.button!.circleColor;
+        settingSide.colors.button!.active.buttonColor = val.previewConfigSide.allButton?.activeBtn ?? settingSide.colors.button!.active.buttonColor;
+        settingSide.colors.button!.inactive.buttonColor = val.previewConfigSide.allButton?.inactiveBtn ?? settingSide.colors.button!.inactive.buttonColor;
       });
     })
 

--- a/src/app/interfaces/change-color-i.ts
+++ b/src/app/interfaces/change-color-i.ts
@@ -21,11 +21,11 @@ export interface ChangeColorI {
     colorOfTextRemove: string;
   },
   previewConfigSide?: {
-    config: string;
-    content: string;
-    text: string;
-    icon: string;
-    allButton: {
+    config?: string;
+    content?: string;
+    text?: string;
+    icon?: string;
+    allButton?: {
       circleColor: string;
       activeBtn: string;
       inactiveBtn: string;


### PR DESCRIPTION
### Descrição  
Esta melhoria adiciona uma lógica que permite que, sempre que o usuário altere a cor de algum elemento do site, a mudança seja refletida **em tempo real nos previews laterais das configurações**. Ou seja, ao modificar a cor através dos inputs, os previews atualizam automaticamente para mostrar a nova aparência do site.
