### PR TITLE
feat(config): desativar animação das configurações ao iniciar em telas menore que 700px

### DIFF
--- a/src/app/components/config/components/animations/animations.scss
+++ b/src/app/components/config/components/animations/animations.scss
@@ -34,6 +34,7 @@
     justify-content: space-around;
     align-items: center;
     flex-wrap: wrap;
+    gap: .5rem;
 
     .animation-wrapper{
       width: clamp(6rem, 20vw, 43%);

--- a/src/app/components/config/config.ts
+++ b/src/app/components/config/config.ts
@@ -89,6 +89,11 @@ export class Config implements OnInit, AfterViewInit{
     this.settingSideService.$settingSideVal.subscribe((val: SettingsSideModel) => {
       this.activeSideConfigBottomTop = val.side === "bottom" || val.side === "top";
     });
+
+    if(window.innerWidth < 700){
+      this.activeResponsive = true;
+      this.openingConfig = true;
+    }
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
Ao iniciar o site com largura menor que 700px, as variáveis `activeResponsive` e `openingConfig` do arquivo `config.ts` agora são inicializadas como `true`, garantindo que o layout responsivo e a configuração lateral estejam ativos desde o carregamento.
