### PR TITLE
style(conteudo.scss): melhorar o 3d do .container-text

### DIFF
--- a/src/app/components/conteudo/conteudo.scss
+++ b/src/app/components/conteudo/conteudo.scss
@@ -6,6 +6,7 @@
   cursor: pointer;
   margin: .5rem;
   position: absolute;
+  z-index: 100;
 
   svg{
     width: 100%;


### PR DESCRIPTION
Adicionei suporte a efeitos 3D nos containers de texto e animação para aprimorar a exibição de transformações tridimensionais e manter a profundidade entre os elementos.
