### PR TITLE
chore: aumentar limite de budget no angular.json para corrigir erro de build

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -46,8 +46,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "8kB",
-                  "maximumError": "12kB"
+                  "maximumWarning": "20kB",
+                  "maximumError": "25kB"
                 }
               ],
               "outputHashing": "all"


### PR DESCRIPTION
### Descrição  
Aumentei o limite de *budget* definido no `angular.json` para corrigir o erro que ocorria durante o processo de build.  

### Motivo  
O build estava falhando porque o arquivo `animations.scss` ultrapassava o limite configurado, impedindo a geração do bundle final.  

### Alterações  
- Ajuste nos valores de `maximumWarning` e `maximumError` no `angular.json`.  
- Garantia de que o build seja concluído sem erros relacionados ao tamanho dos estilos.  

### Resultado esperado  
O build deve ser executado com sucesso, mesmo com o arquivo `animations.scss` acima do limite anterior.
