### PR TITLE
 style(animations.scss): adicionar ./ nos @use para build 

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -30,7 +30,8 @@
               }
             ],
             "styles": [
-              "src/styles.scss"
+              "src/styles.scss",
+              "src/styles/_animationsMixin.scss"
             ],
             "stylePreprocessorOptions": {
               "includePaths": ["src/styles"]
@@ -91,7 +92,8 @@
               }
             ],
             "styles": [
-              "src/styles.scss"
+              "src/styles.scss",
+              "src/styles/_animationsMixin.scss"
             ]
           }
         }

--- a/src/app/components/config/components/animations/animations.scss
+++ b/src/app/components/config/components/animations/animations.scss
@@ -1,5 +1,5 @@
-@use 'animationsMixin' as *;
-@use 'configPreviewStyle' as *;
+@use './animationsMixin' as *;
+@use './configPreviewStyle' as *;
 
 .container{
   width: 100%;


### PR DESCRIPTION
### Descrição  
Adicionei `./` nos caminhos dos arquivos importados com `@use` dentro do `animations.scss` para corrigir problemas de resolução de paths durante o build.

### Motivo  
O build de produção falhava porque o Angular não reconhecia corretamente os caminhos relativos dos arquivos SCSS quando o `@use` não continha o prefixo `./`.

### Alterações  
- Atualização dos imports SCSS para usar caminhos relativos (`@use './animationsMixin' as *;`, por exemplo).  
- Garantia de compatibilidade com o compilador SCSS durante o processo de build e deploy.

### Resultado esperado  
O build deve ser concluído com sucesso e as animações devem funcionar corretamente tanto em ambiente local quanto no ambiente publicado (ex: GitHub Pages).
