### PR TITLE
chore: corrigir erro de build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --base-href=\"https://project-config-full.github.io/web-front/\"",
+    "build": "ng build --base-href=\"/web-front/\"",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"
   },

--- a/src/app/components/config/components/animations/animations.scss
+++ b/src/app/components/config/components/animations/animations.scss
@@ -104,7 +104,7 @@
         $marginOpenConfig: .3rem
       );
 
-      @include animations_config();
+      @include animations_config($preview: true);
 
       .config{
         justify-content: space-evenly;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,3 +1,9 @@
+@use 'animationsMixin' as *;
+
+:root{
+  @include animations_config($preview: true);
+}
+
 *{
   margin: 0;
   padding: 0;


### PR DESCRIPTION
Corrige o problema em que o preview das animações das configurações não era reproduzido corretamente na versão hospedada no GitHub Pages.
