### PR TITLE
fix: tirar o @include animations_config do :root

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,7 +1,7 @@
 @use 'animationsMixin' as *;
 
-:root{
-  @include animations_config($preview: true);
+.load_animation{
+  @include animations_config();
 }
 
 *{


### PR DESCRIPTION
### Descrição
Ajuste realizado para evitar problemas de animação: o `@include animations_config` foi removido do `:root`, pois estava sendo aplicado independentemente do valor do preview (`true` ou `false`). Isso causava conflitos e erros de animação em outros componentes. Com a remoção, as animações passam a funcionar corretamente e apenas onde realmente deveriam ser aplicadas.
